### PR TITLE
Update hero description with research affiliation

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@
         <div class="hero-content">
             <p class="hero-overline">Data Science · Quantitative Finance · ML Research</p>
             <h1 class="hero-title">Edoardo<br><em>Camerinelli</em></h1>
-            <p class="hero-description">Scholarship-awarded Data Scientist and Quantitative Finance researcher. I transform hundreds of gigabytes of raw data into decisions that matter — blending machine learning, statistical rigour, and domain expertise.</p>
+            <p class="hero-description">Scholarship-awarded Data Scientist and research paper author for Starting Finance Club USI. I transform hundreds of gigabytes of raw data into decisions that matter — blending machine learning, statistical rigour, and domain expertise.</p>
             <div class="hero-cta-group">
                 <a href="#projects" class="btn-primary">View Research ↓</a>
                 <a href="#contact" class="btn-outline">Get in Touch</a>


### PR DESCRIPTION
## Summary
Updated the hero section description to include affiliation with Starting Finance Club USI and highlight research paper authorship.

## Changes
- Modified the hero description text to specify role as "research paper author for Starting Finance Club USI" instead of generic "Quantitative Finance researcher"
- Maintains the core message about data transformation and technical expertise while adding institutional context

## Details
This change provides more specific context about the author's research contributions and institutional affiliation, which helps establish credibility and clarifies the nature of their quantitative finance work.

https://claude.ai/code/session_01HNfLf5c5QWji2cfTWZ8H6Z